### PR TITLE
cleanup email receivers

### DIFF
--- a/ckan_pkg_checker/email_builder.py
+++ b/ckan_pkg_checker/email_builder.py
@@ -16,8 +16,12 @@ class EmailBuilder:
         self.csvfile = utils.get_csvdir(rundir) / csvfile
         self.maildir = utils.get_maildir(rundir)
         self.default_contact = utils.Contact(
-            name=utils.get_config(config, "emailbuilder", "default_name", required=True),
-            email=utils.get_config(config, "emailbuilder", "default_email", required=True),
+            name=utils.get_config(
+                config, "emailbuilder", "default_name", required=True
+            ),
+            email=utils.get_config(
+                config, "emailbuilder", "default_email", required=True
+            ),
         )
 
     def build(self):

--- a/ckan_pkg_checker/email_builder.py
+++ b/ckan_pkg_checker/email_builder.py
@@ -15,9 +15,9 @@ class EmailBuilder:
             csvfile = utils.get_config(config, "linkchecker", "csvfile", required=True)
         self.csvfile = utils.get_csvdir(rundir) / csvfile
         self.maildir = utils.get_maildir(rundir)
-        self.admin = self.default_contact = utils.Contact(
-            name=utils.get_config(config, "emailsender", "admin_name", required=True),
-            email=utils.get_config(config, "emailsender", "admin_email", required=True),
+        self.default_contact = utils.Contact(
+            name=utils.get_config(config, "emailbuilder", "default_name", required=True),
+            email=utils.get_config(config, "emailbuilder", "default_email", required=True),
         )
 
     def build(self):
@@ -29,8 +29,8 @@ class EmailBuilder:
 
     def _process_line(self, row):
         contacts = [utils.Contact(email=row["contact_email"], name=row["contact_name"])]
-        if self.admin.email not in [contact.email for contact in contacts]:
-            contacts.append(self.admin)
+        if self.default_contact.email not in [contact.email for contact in contacts]:
+            contacts.append(self.default_contact)
         for contact in contacts:
             pkg_type = row["pkg_type"]
             mailfile = os.path.join(

--- a/ckan_pkg_checker/email_sender.py
+++ b/ckan_pkg_checker/email_sender.py
@@ -18,7 +18,9 @@ class EmailSender:
         )
         self.cc = utils.get_config(config, "emailsender", "cc", required=True)
         bcc = utils.get_config(config, "emailsender", "bcc", required=True)
-        geocat_admin = utils.get_config(config, "emailsender", "geocat_admin", required=True)
+        geocat_admin = utils.get_config(
+            config, "emailsender", "geocat_admin", required=True
+        )
         self.add_as_receivers_for_dcat = [self.cc, bcc]
         self.add_as_receivers_for_geocat = [self.cc, bcc, geocat_admin]
         self.test = test

--- a/ckan_pkg_checker/email_sender.py
+++ b/ckan_pkg_checker/email_sender.py
@@ -16,17 +16,11 @@ class EmailSender:
         self.smtp_server = utils.get_config(
             config, "emailsender", "smtp_server", required=True
         )
-        self.bcc = utils.get_config(config, "emailsender", "bcc", fallback=None)
-        self.admin = self.default_contact = utils.Contact(
-            name=utils.get_config(config, "emailsender", "admin_name", required=True),
-            email=utils.get_config(config, "emailsender", "admin_email", required=True),
-        )
-        self.geocat_admin = utils.Contact(
-            name=utils.get_config(config, "emailsender", "geocat_name", required=True),
-            email=utils.get_config(
-                config, "emailsender", "geocat_email", required=True
-            ),
-        )
+        self.cc = utils.get_config(config, "emailsender", "cc", required=True)
+        bcc = utils.get_config(config, "emailsender", "bcc", required=True)
+        geocat_admin = utils.get_config(config, "emailsender", "geocat_admin", required=True)
+        self.add_as_receivers_for_dcat = [self.cc, bcc]
+        self.add_as_receivers_for_geocat = [self.cc, bcc, geocat_admin]
         self.test = test
         if self.test:
             self.email_overwrites = utils.get_config(
@@ -48,13 +42,13 @@ class EmailSender:
                 send_from = self.sender
 
                 msg["To"] = contact_email
-                send_to = [self.admin.email]
+                msg["Cc"] = self.cc
+
+                send_to = [contact_email]
                 if contact_type == utils.GEOCAT:
-                    send_to.append(self.geocat_admin.email)
-                send_to.append(contact_email)
-                if self.bcc:
-                    msg["Bcc"] = self.bcc
-                    send_to.append(self.bcc)
+                    send_to.extend(self.add_as_receivers_for_geocat)
+                else:
+                    send_to.extend(self.add_as_receivers_for_dcat)
 
                 msg.attach(text)
                 server = smtplib.SMTP(self.smtp_server)

--- a/config.ini.dist
+++ b/config.ini.dist
@@ -32,21 +32,18 @@ shacl_file = ogdch.shacl.ttl
 # organization_slug is the organization slug on opendata.swiss
 csvfile =
 
-[emailsender]
-# admin email and title: all emails go also to the admin
-admin_name =
-admin_email =
-
+[emailbuilder]
 # default email receiver, if no dataset contact can be found
 default_name =
 default_email =
 
-# Title and email for sending emails for datasets harvested by geocat
-geocat_name =
-geocat_email =
-
-#bcc  for sending emails
+[emailsender]
+# add emails for cc and bcc
+cc =
 bcc =
+
+# add geocat email as additional receiver for geocat packages
+geocat_admin =
 
 # email server
 smtp_server = localhost


### PR DESCRIPTION
distinguish between contacts needed for email building and contacts needed for email sending
add configuration for cc and bcc and send silently to bcc but visible to cc