### PR TITLE
adapt subject line to checker mode

### DIFF
--- a/ckan_pkg_checker/email_sender.py
+++ b/ckan_pkg_checker/email_sender.py
@@ -23,13 +23,14 @@ class EmailSender:
         )
         self.add_as_receivers_for_dcat = [self.cc, bcc]
         self.add_as_receivers_for_geocat = [self.cc, bcc, geocat_admin]
+        self.email_subject = utils.get_email_subject(mode=mode)
         self.test = test
         if self.test:
             self.email_overwrites = utils.get_config(
                 config, "test", "emails", required=True
             ).split(" ")
 
-    def send(self):
+    def send(self, mode):
         log.info("sending emails")
         for filename in os.listdir(self.maildir):
             contact_type, contact_email = utils.process_msg_file_name(filename)
@@ -38,7 +39,7 @@ class EmailSender:
                 text = MIMEText(readfile.read(), "html", "utf-8")
                 msg = MIMEMultipart("alternative")
 
-                msg["Subject"] = utils.get_email_subject()
+                msg["Subject"] = self.email_subject
 
                 msg["From"] = self.sender
                 send_from = self.sender

--- a/ckan_pkg_checker/email_sender.py
+++ b/ckan_pkg_checker/email_sender.py
@@ -30,7 +30,7 @@ class EmailSender:
                 config, "test", "emails", required=True
             ).split(" ")
 
-    def send(self, mode):
+    def send(self):
         log.info("sending emails")
         for filename in os.listdir(self.maildir):
             contact_type, contact_email = utils.process_msg_file_name(filename)

--- a/ckan_pkg_checker/email_templates/contact.html
+++ b/ckan_pkg_checker/email_templates/contact.html
@@ -33,8 +33,8 @@
 <br>La preghiamo di verificare se le risorse sono ancora disponibili e, se necessario, correggerle.
 {% elif context.checker_type == context.checker_type_shacl %}
 Metadati mancanti
-[IT] - I seguenti campi dei tuoi dataset pubblicati su opendata.swiss non soddisfano i requisiti del profilo DCAT-AP CH.
-<br>Ti preghiamo di completarli con le informazioni corrispondenti.
+[IT] I seguenti campi dei Suoi dataset pubblicati su opendata.swiss non soddisfano i requisiti del profilo DCAT-AP CH.
+<br>La preghiamo di completarli con le informazioni corrispondenti.
 {% endif %}
 {% if context.pkg_type == context.pkg_type_geocat %}
 <br>I geometadati devono essere attualizzati in <a href='https://www.geocat.ch/geonetwork/srv/ita/catalog.search#/home'>geocat.ch</a>.

--- a/ckan_pkg_checker/email_templates/contact.html
+++ b/ckan_pkg_checker/email_templates/contact.html
@@ -1,4 +1,4 @@
-<p>Hello {{ context.receiver_name | e}}</p>
+<p>Hello {{ context.receiver_name | e }}</p>
 <p>
 {% if context.checker_type == context.checker_type_link %}
 [DE] - Wir haben ein Problem festgestellt beim Versuch, auf folgende Quellen zuzugreifen.
@@ -18,7 +18,7 @@
 [FR] - Nous avons constat&eacute; un probl&egrave;me en essayant d&#39;acc&eacute;der aux ressources suivantes.
 <br>Merci de v&eacute;rifier si ces ressources sont toujours disponibles et de les corriger si n&eacute;cessaire.
 {% elif context.checker_type == context.checker_type_shacl %}
-[FR] - Les champs suivants de vos jeux de données sur opendata.swiss ne répondent pas aux exigences de la DCAT-AP CH.
+[FR] - Les champs suivants de vos jeux de donn&egrave;es sur opendata.swiss ne r&egrave;pondent pas aux exigences de la DCAT-AP CH.
 <br>Veuillez compléter les informations correspondantes.
 {% endif %}
 {% if context.pkg_type == context.pkg_type_geocat %}

--- a/ckan_pkg_checker/email_templates/contact.html
+++ b/ckan_pkg_checker/email_templates/contact.html
@@ -4,8 +4,8 @@
 [DE] - Wir haben ein Problem festgestellt beim Versuch, auf folgende Quellen zuzugreifen.
 <br>Bitte kontrollieren Sie, ob diese Quellen noch zug&auml;nglich sind und korrigieren Sie sie n&ouml;tigenfalls.
 {% elif context.checker_type == context.checker_type_shacl %}
-[DE] - Fehlerhafte Metadaten.
-<br>Nachfolgende Felder Ihrer Datasets auf opendata.swiss entsprechen nicht den Anforderungen von DCAT-AP CH. Bitte erg&auml;nzen Sie die entsprechenden Angaben.
+[DE] - Nachfolgende Felder Ihrer Datasets auf opendata.swiss entsprechen nicht den Anforderungen von DCAT-AP CH.
+<br>Bitte erg&auml;nzen Sie die entsprechenden Angaben.
 {% endif %}
 {% if context.pkg_type == context.pkg_type_geocat %}
 <br>Geometadaten sind in <a href='https://www.geocat.ch/geonetwork/srv/ger/catalog.search#/home'>geocat.ch</a> zu aktualisieren.
@@ -18,8 +18,8 @@
 [FR] - Nous avons constat&eacute; un probl&egrave;me en essayant d&#39;acc&eacute;der aux ressources suivantes.
 <br>Merci de v&eacute;rifier si ces ressources sont toujours disponibles et de les corriger si n&eacute;cessaire.
 {% elif context.checker_type == context.checker_type_shacl %}
-[FR] - Métadonnées erronées
-<br>Les champs suivants de vos jeux de données sur opendata.swiss ne répondent pas aux exigences de la DCAT-AP CH. Veuillez compléter les informations correspondantes.
+[FR] - Les champs suivants de vos jeux de données sur opendata.swiss ne répondent pas aux exigences de la DCAT-AP CH.
+<br>Veuillez compléter les informations correspondantes.
 {% endif %}
 {% if context.pkg_type == context.pkg_type_geocat %}
 <br>Les g&eacute;om&eacute;tadonn&eacute;es doivent &ecirc;tre mises &agrave; jour dans <a href='https://www.geocat.ch/geonetwork/srv/fre/catalog.search#/home'>geocat.ch</a>.
@@ -32,8 +32,9 @@
 [IT] - Abbiamo riscontrato un problema nel tentativo di accedere alle risorse seguenti.
 <br>La preghiamo di verificare se le risorse sono ancora disponibili e, se necessario, correggerle.
 {% elif context.checker_type == context.checker_type_shacl %}
-[IT] - Metadati mancanti
-<br>I seguenti campi dei tuoi dataset pubblicati su opendata.swiss non soddisfano i requisiti del profilo DCAT-AP CH. Ti preghiamo di completarli con le informazioni corrispondenti.
+Metadati mancanti
+[IT] - I seguenti campi dei tuoi dataset pubblicati su opendata.swiss non soddisfano i requisiti del profilo DCAT-AP CH.
+<br>Ti preghiamo di completarli con le informazioni corrispondenti.
 {% endif %}
 {% if context.pkg_type == context.pkg_type_geocat %}
 <br>I geometadati devono essere attualizzati in <a href='https://www.geocat.ch/geonetwork/srv/ita/catalog.search#/home'>geocat.ch</a>.
@@ -46,8 +47,9 @@
 [EN] - While accessing the following resources, we found some unexpected behaviour.
 <br>Please check if those resources are still available.
 {% elif context.checker_type == context.checker_type_shacl %}
-[EN] - Incorrect metadata
-<br>The following fields of your datasets on opendata.swiss do not meet the requirements of DCAT-AP CH. Please complete the corresponding information.
+Incorrect metadata
+[EN] - The following fields of your datasets on opendata.swiss do not meet the requirements of DCAT-AP CH.
+<br>Please complete the corresponding information.
 {% endif %}
 {% if context.pkg_type == context.pkg_type_geocat %}
 <br>Geometadata need to be updated in <a href='https://www.geocat.ch/geonetwork/srv/eng/catalog.search#/home'>geocat.ch</a>.

--- a/ckan_pkg_checker/utils/utils.py
+++ b/ckan_pkg_checker/utils/utils.py
@@ -89,8 +89,11 @@ def get_field_in_one_language(multi_language_field, backup):
         return backup
 
 
-def get_email_subject():
-    return "opendata.swiss : Automatische Kontrolle der Quellen / Controle automatique des ressources / Controllo automatico delle risorse / automatic ressource checker"  # noqa
+def get_email_subject(mode):
+    if mode == MODE_SHACL:
+        return "opendata.swiss : Fehlerhafte Metadaten / Métadonnées erron&eacute;es / Metadati mancanti / Incorrect metadata"  # noqa
+    if mode == MODE_LINK:
+        return "opendata.swiss : opendata.swiss: Fehlerhafte URLs / URL erron&eacute;es / URL errati / Incorrect URLs"
 
 
 def get_pkg_contacts(pkg_contact_points):

--- a/ckan_pkg_checker/utils/utils.py
+++ b/ckan_pkg_checker/utils/utils.py
@@ -43,6 +43,8 @@ GEOCAT = "geocat"
 DCAT = "dcat"
 MODE_SHACL = "shacl"
 MODE_LINK = "link"
+EMAIL_SUBJECT_SHACL = "opendata.swiss : Fehlerhafte Metadaten / Métadonnées erron&eacute;es / Metadati mancanti / Incorrect metadata"
+EMAIL_SUBJECT_LINK = "opendata.swiss : opendata.swiss: Fehlerhafte URLs / URL erron&eacute;es / URL errati / Incorrect URLs"
 
 
 def get_ckan_resource_url(ckan_siteurl, pkg_name, resource_id):
@@ -91,9 +93,9 @@ def get_field_in_one_language(multi_language_field, backup):
 
 def get_email_subject(mode):
     if mode == MODE_SHACL:
-        return "opendata.swiss : Fehlerhafte Metadaten / Métadonnées erron&eacute;es / Metadati mancanti / Incorrect metadata"  # noqa
+        return EMAIL_SUBJECT_SHACL
     if mode == MODE_LINK:
-        return "opendata.swiss : opendata.swiss: Fehlerhafte URLs / URL erron&eacute;es / URL errati / Incorrect URLs"
+        return EMAIL_SUBJECT_LINK
 
 
 def get_pkg_contacts(pkg_contact_points):

--- a/ckan_pkg_checker/utils/utils.py
+++ b/ckan_pkg_checker/utils/utils.py
@@ -43,7 +43,7 @@ GEOCAT = "geocat"
 DCAT = "dcat"
 MODE_SHACL = "shacl"
 MODE_LINK = "link"
-EMAIL_SUBJECT_SHACL = "opendata.swiss : Fehlerhafte Metadaten / Métadonnées erron&eacute;es / Metadati mancanti / Incorrect metadata"
+EMAIL_SUBJECT_SHACL = "opendata.swiss : Fehlerhafte Metadaten / Métadonnées erron&eacute;es / Metadati errati / Incorrect metadata"
 EMAIL_SUBJECT_LINK = "opendata.swiss : opendata.swiss: Fehlerhafte URLs / URL erron&eacute;es / URL errati / Incorrect URLs"
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -118,8 +118,8 @@ class TestResourceCheckMethods(unittest.TestCase):
         self.assertEqual(f"{timestamp}-shacl-org-orgname", runname)
 
     def test__get_email_subject(self):
-        email_subject = utils.get_email_subject()
-        expected_email_subject = "opendata.swiss : Automatische Kontrolle der Quellen / Controle automatique des ressources / Controllo automatico delle risorse / automatic ressource checker"
+        email_subject = utils.get_email_subject(mode=utils.MODE_SHACL)
+        expected_email_subject = utils.EMAIL_SUBJECT_SHACL
         self.assertEqual(email_subject, expected_email_subject)
 
     def test__process_msg_file_name(self):


### PR DESCRIPTION
email subject line should be different for the shacl and link checker
the email headers are adapted so the in case of the shacl checker the information
of the subject line is not repeated in the text