### PR TITLE
fix: load the apikey from the dotenv file

### DIFF
--- a/ckan_pkg_checker/utils/utils.py
+++ b/ckan_pkg_checker/utils/utils.py
@@ -1,6 +1,7 @@
 import configparser
 import csv
 import logging
+import os
 import sys
 from collections import defaultdict, namedtuple
 from configparser import NoOptionError, NoSectionError
@@ -10,6 +11,7 @@ from urllib.parse import urljoin
 
 import ckanapi
 import click
+from dotenv import dotenv_values, load_dotenv
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 env = Environment(
@@ -28,6 +30,7 @@ RunParms = namedtuple(
         "pkg",
         "limit",
         "config",
+        "apikey",
         "tmpdir",
         "rundir",
         "mode",
@@ -248,7 +251,7 @@ def set_up_contact_mapping(config, ogdremote):
         if not organization_admin_emails:
             continue
         contact_dict[dcat_contact_key] = organization_admin_emails
-    for entry, value in contact_dict:
+    for entry, value in contact_dict.items():
         log_and_echo_msg(f"{entry} is emailed to: {value}")
     return contact_dict
 
@@ -350,6 +353,9 @@ def set_runparms(org, limit, pkg, run, configpath, build, send, mode, test):
 
     tmpdir = Path(get_config(config, "tmpdir", "tmppath", required=True))
     siteurl = get_config(config, "site", "siteurl", required=True)
+    envpath = get_config(config, "env", "envpath", required=True)
+    load_dotenv(dotenv_path=envpath)
+    apikey = os.environ.get("CKAN_API_KEY")
     if run:
         mode = _get_mode_from_runname(run)
         check = False
@@ -364,6 +370,7 @@ def set_runparms(org, limit, pkg, run, configpath, build, send, mode, test):
         pkg=pkg,
         limit=limit,
         config=config,
+        apikey=apikey,
         tmpdir=tmpdir,
         rundir=rundir,
         mode=mode,

--- a/config.ini.dist
+++ b/config.ini.dist
@@ -3,6 +3,10 @@
 # alternatives are the ckan test and abnahme instance of opendata.swiss
 siteurl = https://ckan.opendata.swiss
 
+[env]
+# Path to .env file
+envpath =
+
 [tmpdir]
 # put a custom path here where you want to receive your output
 tmppath =

--- a/pkg_checker.py
+++ b/pkg_checker.py
@@ -4,7 +4,6 @@ Script to start the Worklogdb Application
 import logging
 
 import click
-from dotenv import dotenv_values, load_dotenv
 
 from ckan_pkg_checker.email_builder import EmailBuilder
 from ckan_pkg_checker.email_sender import EmailSender
@@ -104,9 +103,6 @@ def check_packages(
     You can just send emails when you run the command with --run and --send.
     This assumes a previous check run has been taken place.
     """
-    load_dotenv()
-    config = dotenv_values(".env")
-    apikey = config.get("CKAN_API_KEY")
     runparms = set_runparms(
         org=org,
         limit=limit,
@@ -123,7 +119,7 @@ def check_packages(
         check = PackageCheck(
             config=runparms.config,
             siteurl=runparms.siteurl,
-            apikey=apikey,
+            apikey=runparms.apikey,
             rundir=runparms.rundir,
             mode=runparms.mode,
             limit=runparms.limit,


### PR DESCRIPTION
make sure the loading works even when the checker is started as
a cron job: the location of the .env file is specified in the
configuration file