### PR TITLE
feat: improve contact_dict build up

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ The emails go to the contacts mentioned in the packages and additionally some ad
 In case the contact for the metadata of an organization differs from the contact given in the packages, this can be specified in a csv file with the following fields:
 
 ```
-pkg_type,organization_slug,contact_email
-geocat,example-org,example-contact-email@gmail.com
+pkg_type,organization_slug,contact_emails
+geocat,example-org,example-contact1-email@gmail.com example-contact2-email@gmail.com
 dcat,other-example-org,other-contact-email@org.ch
 ```
 
@@ -96,8 +96,20 @@ These fields are to be filled as follows:
 
 - `pkg_type`: `geocat` for datasets that are harvested from https://geocat.ch, `dcat` for all other datasets
 - `organization_slug`: slug of the organization on https://opendata.swiss
-- `contact_email`: metadata contact for that organization: an email of a peron or organization that can change the metadata of datasets of that organization
+- `contact_emails`: metadata contacts for that organization: an email of a person of the organization that can change the metadata of datasets of that organization: more than one email can be added; separate emails by a blank
   
+The emails for geocat datasets will be send to:
+
+1. the contacts on the list if there are any
+2. in case no contacts are on the list the contact-point specified in the dataset will be taken
+
+The emails for geocat datasets will be send to:
+
+1. the contacts on the list if there are any
+2. in case no contacts are on the list the organization-admins will be taken as contacts
+3. in case no organisation-admins are available the parent organization organization admins will be taken
+4. in case there are still no contacts the contact-points specified in the dataset will be taken
+
 ## Install 
 
 ```

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The emails for geocat datasets will be send to:
 1. the contacts on the list if there are any
 2. in case no contacts are on the list the contact-point specified in the dataset will be taken
 
-The emails for geocat datasets will be send to:
+The emails for dcat datasets will be send to:
 
 1. the contacts on the list if there are any
 2. in case no contacts are on the list the organization-admins will be taken as contacts

--- a/ckan_pkg_checker/utils/utils.py
+++ b/ckan_pkg_checker/utils/utils.py
@@ -194,9 +194,20 @@ def get_config(config, section, option, required=False, fallback=None):
     return value
 
 
+def _get_parent_organization_dict(organizatons):
+    parents = {
+        org.get("name"): [parent.get("name") for parent in org.get("groups")]
+        for org in organizatons
+    }
+    return parents
+
+
 def _get_organization_list(ogdremote):
     try:
-        return ogdremote.action.organization_list()
+        organizations = ogdremote.action.organization_list(
+            all_fields=True, include_groups=True, include_dataset_count=False
+        )
+        return _get_parent_organization_dict(organizations)
     except ckanapi.errors.NotFound:
         log_and_echo_msg(f"No organization found for id: {id}")
     except ckanapi.errors.CKANAPIError:
@@ -232,9 +243,9 @@ def _get_organization_admin_emails(ogdremote, userids):
 
 
 def set_up_contact_mapping(config, ogdremote):
-    organization_names = _get_organization_list(ogdremote)
+    organization_with_parents = _get_organization_list(ogdremote)
     contact_dict = _get_contacts_from_file(config)
-    for organization_name in organization_names:
+    for organization_name in organization_with_parents:
         dcat_contact_key = ContactKey(organization_name, DCAT)
         if dcat_contact_key in contact_dict:
             continue
@@ -242,6 +253,14 @@ def set_up_contact_mapping(config, ogdremote):
             ogdremote,
             organization_name,
         )
+        if (
+            not organization_admin_userids
+            and organization_with_parents[organization_name]
+        ):
+            organization_admin_userids = _get_organization_admin_userids(
+                ogdremote,
+                organization_with_parents[organization_name][0],
+            )
         if not organization_admin_userids:
             continue
         organization_admin_emails = _get_organization_admin_emails(
@@ -258,7 +277,7 @@ def set_up_contact_mapping(config, ogdremote):
 
 def _get_contacts_from_file(config):
     contact_file = get_config(config, "contacts", "csvfile", fallback=None)
-    contact_dict = {}
+    contact_dict = defaultdict(list)
     if contact_file:
         try:
             with open(contact_file, "r") as csvfile:
@@ -267,16 +286,14 @@ def _get_contacts_from_file(config):
                     if (
                         not row.get("organization_slug")
                         or not row.get("pkg_type")
-                        or not row.get("contact_email")
+                        or not row.get("contact_emails")
                     ):
                         continue
                     contact_key = ContactKey(
                         organization=row["organization_slug"], pkg_type=row["pkg_type"]
                     )
-                    if contact_key in contact_dict:
-                        contact_dict[contact_key].append(row["contact_email"])
-                        continue
-                    contact_dict[contact_key] = [row["contact_email"]]
+                    emails = row["contact_emails"].split(" ")
+                    contact_dict[contact_key].extend(emails)
         except FileNotFoundError:
             raise click.UsageError(
                 "'contacts.csv' file configured, but file was not found."


### PR DESCRIPTION
in the file contacts.csv replace email with emails: the emails are
suppossed to be separated by a blank

when looking for organization admins, also consider the parent
organization: in case no organization admins can be found for
an organization, then try to get the admins of the parent
organization instead