### PR TITLE
feat: add contact statistics email

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ The emails for dcat datasets will be send to:
 3. in case no organisation-admins are available the parent organization organization admins will be taken
 4. in case there are still no contacts the dcat_admin email will be taken from the config file
 
+### Statistics
+
+The checker sends additional emails with some statistics about each run to the default contsct.
+The followings statistics will be emailed:
+
+- a list of checks that have been performed together with the counts of how often the errors occured
+- a list of organizations with the contacts that have been informed together with the counts of errors that have been reported to them
+
 ## Install 
 
 ```

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The emails for dcat datasets will be send to:
 
 ### Statistics
 
-The checker sends additional emails with some statistics about each run to the default contsct.
+The checker sends additional emails with some statistics about each run to the default contact.
 The followings statistics will be emailed:
 
 - a list of checks that have been performed together with the counts of how often the errors occured

--- a/ckan_pkg_checker/checkers/link_checker.py
+++ b/ckan_pkg_checker/checkers/link_checker.py
@@ -36,6 +36,9 @@ class LinkChecker(CheckerInterface):
         self.statfilepath = runpath / utils.get_config(
             config, "linkchecker", "statfile", required=True
         )
+        self.contactsstats_filename = utils.get_csvdir(rundir) / utils.get_config(
+            config, "contacts", "statsfile", required=True
+        )
         self._prepare_csv_file()
 
     def _prepare_csv_file(self):
@@ -99,6 +102,11 @@ class LinkChecker(CheckerInterface):
     def finish(self):
         self.csvfile.close()
         self._statistics()
+        utils.contacts_statistics(
+            checker_result_path=self.csvfilepath,
+            contactsstats_filename=self.contactsstats_filename,
+            checker_error_fieldname="error_message",
+        )
 
     def _check_resource(self, pkg, resource):
         """Check one resource"""

--- a/ckan_pkg_checker/checkers/link_checker.py
+++ b/ckan_pkg_checker/checkers/link_checker.py
@@ -36,7 +36,7 @@ class LinkChecker(CheckerInterface):
         self.statfilepath = runpath / utils.get_config(
             config, "linkchecker", "statfile", required=True
         )
-        self.contactsstats_filename = utils.get_csvdir(rundir) / utils.get_config(
+        self.contactsstats_filename = runpath / utils.get_config(
             config, "contacts", "statsfile", required=True
         )
         self._prepare_csv_file()

--- a/ckan_pkg_checker/checkers/shacl_checker.py
+++ b/ckan_pkg_checker/checkers/shacl_checker.py
@@ -22,6 +22,9 @@ class ShaclChecker(CheckerInterface):
         self.statfilename = utils.get_csvdir(rundir) / utils.get_config(
             config, "shaclchecker", "statfile", required=True
         )
+        self.contactsstats_filename = utils.get_csvdir(rundir) / utils.get_config(
+            config, "contacts", "statsfile", required=True
+        )
         shaclfile = utils.get_config(
             config, "shaclchecker", "shacl_file", required=True
         )
@@ -127,6 +130,11 @@ class ShaclChecker(CheckerInterface):
         """Close the file"""
         self.csvfile.close()
         self._statistics()
+        utils.contacts_statistics(
+            checker_result_path=self.csvfilename,
+            contactsstats_filename=self.contactsstats_filename,
+            checker_error_fieldname="error_msg",
+        )
 
     def _statistics(self):
         df = pd.read_csv(self.csvfilename)

--- a/ckan_pkg_checker/checkers/shacl_checker.py
+++ b/ckan_pkg_checker/checkers/shacl_checker.py
@@ -16,13 +16,14 @@ class ShaclChecker(CheckerInterface):
     def __init__(self, rundir, config, siteurl):
         """Initialize the validation checker"""
         self.siteurl = siteurl
-        self.csvfilename = utils.get_csvdir(rundir) / utils.get_config(
+        runpath = utils.get_csvdir(rundir)
+        self.csvfilename = runpath / utils.get_config(
             config, "shaclchecker", "csvfile", required=True
         )
-        self.statfilename = utils.get_csvdir(rundir) / utils.get_config(
+        self.statfilename = runpath / utils.get_config(
             config, "shaclchecker", "statfile", required=True
         )
-        self.contactsstats_filename = utils.get_csvdir(rundir) / utils.get_config(
+        self.contactsstats_filename = runpath / utils.get_config(
             config, "contacts", "statsfile", required=True
         )
         shaclfile = utils.get_config(

--- a/ckan_pkg_checker/email_builder.py
+++ b/ckan_pkg_checker/email_builder.py
@@ -28,7 +28,7 @@ class EmailBuilder:
             self.statpath = runpath / utils.get_config(
                 config, "linkchecker", "statfile", required=True
             )
-        self.contactsstats_path = utils.get_csvdir(rundir) / utils.get_config(
+        self.contactsstats_path = runpath / utils.get_config(
             config, "contacts", "statsfile", required=True
         )
         self.default_contact = utils.Contact(

--- a/ckan_pkg_checker/email_builder.py
+++ b/ckan_pkg_checker/email_builder.py
@@ -28,6 +28,9 @@ class EmailBuilder:
             self.statpath = runpath / utils.get_config(
                 config, "linkchecker", "statfile", required=True
             )
+        self.contactsstats_path = utils.get_csvdir(rundir) / utils.get_config(
+            config, "contacts", "statsfile", required=True
+        )
         self.default_contact = utils.Contact(
             name=utils.get_config(
                 config, "emailbuilder", "default_name", required=True
@@ -45,6 +48,8 @@ class EmailBuilder:
                 self._process_line(row)
         if self.statpath:
             self._build_statistics()
+        if self.contactsstats_path:
+            self._build_contacts_statistics()
 
     def _process_line(self, row):
         contacts = [utils.Contact(email=row["contact_email"], name=row["contact_name"])]
@@ -81,5 +86,18 @@ class EmailBuilder:
                 receiver_name=self.default_contact.name,
                 mode=self.mode,
                 statistics=statistics,
+            )
+            writemail.write(msg)
+
+    def _build_contacts_statistics(self):
+        filename = utils.CONTACTS_STATISTICS + "#" + self.default_contact.email
+        mailfile = os.path.join(self.mailpath, filename + ".html")
+        utils.log_and_echo_msg(f"email for {filename}")
+        with open(mailfile, "a") as writemail:
+            df = pd.read_csv(self.contactsstats_path)
+            msg = utils.build_contacts_statistics_email(
+                receiver_name=self.default_contact.name,
+                mode=self.mode,
+                df_statistics=df,
             )
             writemail.write(msg)

--- a/ckan_pkg_checker/email_templates/contact_statistics.html
+++ b/ckan_pkg_checker/email_templates/contact_statistics.html
@@ -1,0 +1,26 @@
+<style>
+table, th, td {
+  border: 1px solid black;
+  padding: 5px;
+  border-collapse: collapse;
+}
+</style>
+<p>Hello {{ context.receiver_name | e}}</p>
+<p>This is a summary of the results of the {{ context.mode }} shecker run per organization.</p>
+<p>Emails have been sent to the following contacts:</p>
+<table>
+  <tr>
+    <th>Organization Name</th>
+    <th>Package Type</th>
+    <th>Contact emails</th>
+    <th>Error Count</th>
+  </tr>
+  {% for result in context.rows %}
+  <tr>
+    <td>{{ result.organization_name }}</td>
+    <td>{{ result.pkg_type }}</td>
+    <td>{{ result.contact_emails }}</td>
+    <td>{{ result.error_count }}</td>
+  </tr>
+  {% endfor %}
+</table>

--- a/ckan_pkg_checker/utils/utils.py
+++ b/ckan_pkg_checker/utils/utils.py
@@ -497,13 +497,13 @@ def contacts_statistics(
     checker_result_path, checker_error_fieldname, contactsstats_filename
 ):
     df = pd.read_csv(checker_result_path)
-    df_contacts = df.filter(["contact_email", "pkg_type", "organization_name"])
-    df_errors = df.filter([checker_error_fieldname, "pkg_type", "organization_name"])
-    dg_contacts = df_contacts.groupby(["organization_name", "pkg_type"]).apply(
-        _list_contact_emails
-    )
+    dg_contacts = df.filter(["contact_email", "pkg_type", "organization_name"])\
+                    .groupby(["organization_name", "pkg_type"]).apply(
+                        _list_contact_emails
+                    )
     dg_contacts.name = "contacts"
-    dg_errors = df_errors.groupby(["organization_name", "pkg_type"]).count()
+    dg_errors = df.filter([checker_error_fieldname, "pkg_type", "organization_name"])\
+                  .groupby(["organization_name", "pkg_type"]).count()
     df_result = dg_errors.join(dg_contacts)
     statfile = open(contactsstats_filename, "w")
     statwriter = csv.DictWriter(

--- a/ckan_pkg_checker/utils/utils.py
+++ b/ckan_pkg_checker/utils/utils.py
@@ -497,13 +497,17 @@ def contacts_statistics(
     checker_result_path, checker_error_fieldname, contactsstats_filename
 ):
     df = pd.read_csv(checker_result_path)
-    dg_contacts = df.filter(["contact_email", "pkg_type", "organization_name"])\
-                    .groupby(["organization_name", "pkg_type"]).apply(
-                        _list_contact_emails
-                    )
+    dg_contacts = (
+        df.filter(["contact_email", "pkg_type", "organization_name"])
+        .groupby(["organization_name", "pkg_type"])
+        .apply(_list_contact_emails)
+    )
     dg_contacts.name = "contacts"
-    dg_errors = df.filter([checker_error_fieldname, "pkg_type", "organization_name"])\
-                  .groupby(["organization_name", "pkg_type"]).count()
+    dg_errors = (
+        df.filter([checker_error_fieldname, "pkg_type", "organization_name"])
+        .groupby(["organization_name", "pkg_type"])
+        .count()
+    )
     df_result = dg_errors.join(dg_contacts)
     statfile = open(contactsstats_filename, "w")
     statwriter = csv.DictWriter(

--- a/ckan_pkg_checker/utils/utils.py
+++ b/ckan_pkg_checker/utils/utils.py
@@ -11,6 +11,7 @@ from urllib.parse import urljoin
 
 import ckanapi
 import click
+import pandas as pd
 from dotenv import dotenv_values, load_dotenv
 from jinja2 import Environment, PackageLoader, select_autoescape
 
@@ -44,6 +45,7 @@ FieldNamesMsgFile = ["contact_email", "contact_name", "pkg_type", "checker_type"
 GEOCAT = "geocat"
 DCAT = "dcat"
 STATISTICS = "statistics"
+CONTACTS_STATISTICS = "contacts-statistics"
 MODE_SHACL = "shacl"
 MODE_LINK = "link"
 modes = [MODE_LINK, MODE_SHACL]
@@ -106,6 +108,28 @@ def build_statistics_email(receiver_name, mode, statistics):
             "mode": mode,
             "checks": display_checks,
             "errors": display_errors,
+        }
+    )
+    return html
+
+
+def build_contacts_statistics_email(receiver_name, mode, df_statistics):
+    stat_template = env.get_template("contact_statistics.html")
+    organization_results = list()
+    for _, row in df_statistics.iterrows():
+        organization_results.append(
+            {
+                "organization_name": row["organization_name"],
+                "pkg_type": row["pkg_type"],
+                "contact_emails": row["contact_emails"],
+                "error_count": row["error_count"],
+            }
+        )
+    html = stat_template.render(
+        context={
+            "receiver_name": receiver_name,
+            "mode": mode,
+            "rows": organization_results,
         }
     )
     return html
@@ -467,3 +491,39 @@ def _get_mode_from_runname(runname):
         return mode[0]
     else:
         raise click.UsageError(f"Mode can not be detected from {runname}.")
+
+
+def contacts_statistics(
+    checker_result_path, checker_error_fieldname, contactsstats_filename
+):
+    df = pd.read_csv(checker_result_path)
+    df_contacts = df.filter(["contact_email", "pkg_type", "organization_name"])
+    df_errors = df.filter([checker_error_fieldname, "pkg_type", "organization_name"])
+    dg_contacts = df_contacts.groupby(["organization_name", "pkg_type"]).apply(
+        _list_contact_emails
+    )
+    dg_contacts.name = "contacts"
+    dg_errors = df_errors.groupby(["organization_name", "pkg_type"]).count()
+    df_result = dg_errors.join(dg_contacts)
+    statfile = open(contactsstats_filename, "w")
+    statwriter = csv.DictWriter(
+        statfile,
+        fieldnames=["organization_name", "pkg_type", "error_count", "contact_emails"],
+    )
+    statwriter.writeheader()
+    for index, row in df_result.iterrows():
+        statwriter.writerow(
+            {
+                "organization_name": index[0],
+                "pkg_type": index[1],
+                "error_count": row[checker_error_fieldname],
+                "contact_emails": row["contacts"],
+            }
+        )
+
+
+def _list_contact_emails(df):
+    contacts = df["contact_email"].to_list()
+    contacts_unique = list(set(contacts))
+    contacts_unique_formatted = " ".join(contacts_unique)
+    return contacts_unique_formatted


### PR DESCRIPTION
the email goes to the default contact: it is similar to the already
mailed statistics. Difference:

- the results are split up by organization
- they contain the overall error number
- they also contain the email adresses of who got mail about these
  errors