### PR TITLE
Verify newly added properties with the link checker

### DIFF
--- a/ckan_pkg_checker/checkers/link_checker.py
+++ b/ckan_pkg_checker/checkers/link_checker.py
@@ -179,19 +179,17 @@ class LinkChecker(CheckerInterface):
 
     def _check_resource_url(self, url, test_title, resource_id, resource_results):
         """Verify a single resource URL"""
-        check_result = self._check_url_status(
-            test_title, url, resource_id
-        )
+        check_result = self._check_url_status(test_title, url, resource_id)
         if check_result:
             resource_results.append(check_result)
 
-    def _check_resource_url_from_list(self, urls, test_title, resource_id, resource_results):
+    def _check_resource_url_from_list(
+        self, urls, test_title, resource_id, resource_results
+    ):
         """Verify resource URLs within the list"""
         for url in urls:
             if url:
-                check_result = self._check_url_status(
-                    test_title, url, resource_id
-                )
+                check_result = self._check_url_status(test_title, url, resource_id)
                 if check_result:
                     resource_results.append(check_result)
 
@@ -206,27 +204,36 @@ class LinkChecker(CheckerInterface):
             pass
         if access_url:
             self._check_resource_url(
-                 url=access_url, test_title=TEST_ACCESS_URL, resource_id=resource["id"], resource_results=resource_results
+                url=access_url,
+                test_title=TEST_ACCESS_URL,
+                resource_id=resource["id"],
+                resource_results=resource_results,
             )
 
         if download_url and download_url != access_url:
             self._check_resource_url(
-                url=download_url, test_title=TEST_DOWNLOAD_URL, resource_id=resource["id"],
-                resource_results=resource_results
+                url=download_url,
+                test_title=TEST_DOWNLOAD_URL,
+                resource_id=resource["id"],
+                resource_results=resource_results,
             )
 
         # Check documentation URLs for the resources
         if "documentation" in resource:
             self._check_resource_url_from_list(
-                urls=resource.get("documentation"), test_title=TEST_RESOURCE_DOCUMENTATION_URL, resource_id=resource["id"],
-                resource_results=resource_results
+                urls=resource.get("documentation"),
+                test_title=TEST_RESOURCE_DOCUMENTATION_URL,
+                resource_id=resource["id"],
+                resource_results=resource_results,
             )
 
         # Check documentation URLs for the resources
         if "access_services" in resource:
             self._check_resource_url_from_list(
-                urls=resource.get("access_services"), test_title=TEST_ACCESS_SERVICES_URL, resource_id=resource["id"],
-                resource_results=resource_results
+                urls=resource.get("access_services"),
+                test_title=TEST_ACCESS_SERVICES_URL,
+                resource_id=resource["id"],
+                resource_results=resource_results,
             )
         return resource_results
 

--- a/ckan_pkg_checker/checkers/link_checker.py
+++ b/ckan_pkg_checker/checkers/link_checker.py
@@ -75,11 +75,7 @@ class LinkChecker(CheckerInterface):
         check_results = []
 
         # Check landing page URL
-        landing_page = pkg.get("url")
-        if landing_page:
-            check_result = self._check_url_status(TEST_LANDING_PAGE_URL, landing_page)
-            if check_result:
-                check_results.append(check_result)
+        self._check_url(pkg, "url", TEST_LANDING_PAGE_URL, check_results)
 
         # Check publisher URL - mandatory field
         # exm.,'publisher':'{
@@ -92,53 +88,28 @@ class LinkChecker(CheckerInterface):
             except json.JSONDecodeError:
                 log.error("Error decoding JSON for 'publisher'")
 
-        publisher_url = pkg["publisher"].get("url")
-        if publisher_url:
-            check_result = self._check_url_status(TEST_PUBLISHER_URL, publisher_url)
-            if check_result:
-                check_results.append(check_result)
+        self._check_url(pkg["publisher"], "url",
+                        TEST_PUBLISHER_URL, check_results)
 
         # Check relations URL
         if "relations" in pkg:
-            for relation in pkg["relations"]:
-                relation_url = relation.get("url")
-                if relation_url:
-                    check_result = self._check_url_status(
-                        TEST_RELATION_URL, relation_url
-                    )
-                    if check_result:
-                        check_results.append(check_result)
+            self._check_url_from_list_dict(pkg["relations"], "url",
+                                           TEST_RELATION_URL, check_results)
 
         # Check qualified relations URL
         if "qualified_relations" in pkg:
-            for qualified_relation in pkg["qualified_relations"]:
-                qualified_relation_url = qualified_relation.get("relation")
-                if qualified_relation_url:
-                    check_result = self._check_url_status(
-                        TEST_QUALIFIED_RELATION_URL, qualified_relation_url
-                    )
-                    if check_result:
-                        check_results.append(check_result)
+            self._check_url_from_list_dict(pkg["qualified_relations"], "relation",
+                                           TEST_QUALIFIED_RELATION_URL, check_results)
 
         # Check conforms to URLs
         if "conforms_to" in pkg:
-            for conforms_to_url in pkg["conforms_to"]:
-                if conforms_to_url:
-                    check_result = self._check_url_status(
-                        TEST_CONFORMS_TO_URL, conforms_to_url
-                    )
-                    if check_result:
-                        check_results.append(check_result)
+            self._check_url_from_list(pkg, "conforms_to",
+                                      TEST_CONFORMS_TO_URL, check_results)
 
         # Check documentation URLs
         if "documentation" in pkg:
-            for documentation_url in pkg["documentation"]:
-                if documentation_url:
-                    check_result = self._check_url_status(
-                        TEST_CONFORMS_TO_URL, documentation_url
-                    )
-                    if check_result:
-                        check_results.append(check_result)
+            self._check_url_from_list(pkg, "documentation",
+                                      TEST_DOCUMENTATION_URL, check_results)
 
         for resource in pkg["resources"]:
             log.info(
@@ -167,6 +138,33 @@ class LinkChecker(CheckerInterface):
             contactsstats_filename=self.contactsstats_filename,
             checker_error_fieldname="error_message",
         )
+
+    def _check_url(self, pkg, key, test_title, check_results):
+        """Verify a single URL"""
+        url = pkg.get(key)
+        if url:
+            check_result = self._check_url_status(test_title, url)
+            if check_result:
+                check_results.append(check_result)
+
+    def _check_url_from_list(self, pkg, key, test_title, check_results):
+        """Verify URLs within the list"""
+        urls = pkg.get(key)
+        if urls:
+            for url in urls:
+                if url:
+                    check_result = self._check_url_status(test_title, url)
+                    if check_result:
+                        check_results.append(check_result)
+
+    def _check_url_from_list_dict(self, list_dict, key, test_title, check_results):
+        """Verify URLs within the list of dictionaries"""
+        for dict in list_dict:
+            url = dict.get(key)
+            if url:
+                check_result = self._check_url_status(test_title, url)
+                if check_result:
+                    check_results.append(check_result)
 
     def _check_resource(self, pkg, resource):
         """Check one resource"""

--- a/ckan_pkg_checker/checkers/link_checker.py
+++ b/ckan_pkg_checker/checkers/link_checker.py
@@ -101,9 +101,7 @@ class LinkChecker(CheckerInterface):
 
         publisher_url = pkg["publisher"].get("url")
         self._check_url(
-            url=publisher_url,
-            test_title=TEST_PUBLISHER_URL,
-            results=check_results
+            url=publisher_url, test_title=TEST_PUBLISHER_URL, results=check_results
         )
 
         # Check relations URL

--- a/ckan_pkg_checker/checkers/link_checker.py
+++ b/ckan_pkg_checker/checkers/link_checker.py
@@ -22,6 +22,7 @@ TEST_PUBLISHER_URL = "dct:publisher"
 TEST_CONFORMS_TO_URL = "dct:conformsTo"
 TEST_DOCUMENTATION_URL = "foaf:page"
 TEST_DOWNLOAD_URL = "dcat:downloadURL"
+TEST_DOWNLOAD_URL = "dcat:downloadURL"
 link_checks = [
     TEST_ACCESS_URL,
     TEST_RELATION_URL,
@@ -193,6 +194,16 @@ class LinkChecker(CheckerInterface):
             )
             if check_result:
                 resource_results.append(check_result)
+        # Check documentation URLs for the resources
+        if "documentation" in resource:
+            for documentation_url in resource.get("documentation"):
+                if documentation_url:
+                    check_result = self._check_url_status(
+                        TEST_DOCUMENTATION_URL, documentation_url, resource["id"]
+                    )
+                    if check_result:
+                        resource_results.append(check_result)
+
         return resource_results
 
     def _check_url_status(self, test_title, test_url, resource_id=None):

--- a/ckan_pkg_checker/checkers/link_checker.py
+++ b/ckan_pkg_checker/checkers/link_checker.py
@@ -88,28 +88,34 @@ class LinkChecker(CheckerInterface):
             except json.JSONDecodeError:
                 log.error("Error decoding JSON for 'publisher'")
 
-        self._check_url(pkg["publisher"], "url",
-                        TEST_PUBLISHER_URL, check_results)
+        self._check_url(pkg["publisher"], "url", TEST_PUBLISHER_URL, check_results)
 
         # Check relations URL
         if "relations" in pkg:
-            self._check_url_from_list_dict(pkg["relations"], "url",
-                                           TEST_RELATION_URL, check_results)
+            self._check_url_from_list_dict(
+                pkg["relations"], "url", TEST_RELATION_URL, check_results
+            )
 
         # Check qualified relations URL
         if "qualified_relations" in pkg:
-            self._check_url_from_list_dict(pkg["qualified_relations"], "relation",
-                                           TEST_QUALIFIED_RELATION_URL, check_results)
+            self._check_url_from_list_dict(
+                pkg["qualified_relations"],
+                "relation",
+                TEST_QUALIFIED_RELATION_URL,
+                check_results,
+            )
 
         # Check conforms to URLs
         if "conforms_to" in pkg:
-            self._check_url_from_list(pkg, "conforms_to",
-                                      TEST_CONFORMS_TO_URL, check_results)
+            self._check_url_from_list(
+                pkg, "conforms_to", TEST_CONFORMS_TO_URL, check_results
+            )
 
         # Check documentation URLs
         if "documentation" in pkg:
-            self._check_url_from_list(pkg, "documentation",
-                                      TEST_DOCUMENTATION_URL, check_results)
+            self._check_url_from_list(
+                pkg, "documentation", TEST_DOCUMENTATION_URL, check_results
+            )
 
         for resource in pkg["resources"]:
             log.info(

--- a/ckan_pkg_checker/checkers/link_checker.py
+++ b/ckan_pkg_checker/checkers/link_checker.py
@@ -19,6 +19,7 @@ TEST_RELATION_URL = "dct:relation"
 TEST_QUALIFIED_RELATION_URL = "dcat:qualifiedRelation"
 TEST_LANDING_PAGE_URL = "dcat:landingPage"
 TEST_PUBLISHER_URL = "dct:publisher"
+TEST_CONFORMS_TO_URL = "dct:conformsTo"
 TEST_DOWNLOAD_URL = "dcat:downloadURL"
 link_checks = [
     TEST_ACCESS_URL,
@@ -26,6 +27,7 @@ link_checks = [
     TEST_QUALIFIED_RELATION_URL,
     TEST_LANDING_PAGE_URL,
     TEST_PUBLISHER_URL,
+    TEST_CONFORMS_TO_URL,
     TEST_DOWNLOAD_URL,
 ]
 
@@ -113,6 +115,16 @@ class LinkChecker(CheckerInterface):
                 if qualified_relation_url:
                     check_result = self._check_url_status(
                         TEST_QUALIFIED_RELATION_URL, qualified_relation_url
+                    )
+                    if check_result:
+                        check_results.append(check_result)
+
+        # Check conforms to URL
+        if "conforms_to" in pkg:
+            for conforms_to_url in pkg["conforms_to"]:
+                if conforms_to_url:
+                    check_result = self._check_url_status(
+                        TEST_CONFORMS_TO_URL, conforms_to_url
                     )
                     if check_result:
                         check_results.append(check_result)

--- a/ckan_pkg_checker/checkers/link_checker.py
+++ b/ckan_pkg_checker/checkers/link_checker.py
@@ -20,6 +20,7 @@ TEST_QUALIFIED_RELATION_URL = "dcat:qualifiedRelation"
 TEST_LANDING_PAGE_URL = "dcat:landingPage"
 TEST_PUBLISHER_URL = "dct:publisher"
 TEST_CONFORMS_TO_URL = "dct:conformsTo"
+TEST_DOCUMENTATION_URL = "foaf:page"
 TEST_DOWNLOAD_URL = "dcat:downloadURL"
 link_checks = [
     TEST_ACCESS_URL,
@@ -119,12 +120,22 @@ class LinkChecker(CheckerInterface):
                     if check_result:
                         check_results.append(check_result)
 
-        # Check conforms to URL
+        # Check conforms to URLs
         if "conforms_to" in pkg:
             for conforms_to_url in pkg["conforms_to"]:
                 if conforms_to_url:
                     check_result = self._check_url_status(
                         TEST_CONFORMS_TO_URL, conforms_to_url
+                    )
+                    if check_result:
+                        check_results.append(check_result)
+
+        # Check documentation URLs
+        if "documentation" in pkg:
+            for documentation_url in pkg["documentation"]:
+                if documentation_url:
+                    check_result = self._check_url_status(
+                        TEST_CONFORMS_TO_URL, documentation_url
                     )
                     if check_result:
                         check_results.append(check_result)


### PR DESCRIPTION
Adding new properties that we have added last conform. sprint and before:

For dataset:

-publisher url
-qualified relations
-conforms to urls 
-documentation urls

For Resources:

-documentation urls
-access_services