### PR TITLE
refactor: query harvesters via package_search

### DIFF
--- a/ckan_pkg_checker/pkg_checker.py
+++ b/ckan_pkg_checker/pkg_checker.py
@@ -107,11 +107,18 @@ class PackageCheck:
 
     def _get_dcat_harvester_dict(self):
         try:
-            harvesters = self.ogdremote.action.harvest_source_list()
+            search_dict = self.ogdremote.call_action(
+                "package_search",
+                {"fq": "dataset_type:harvest", "rows": 500},
+            )
+
             harvester_dict = {}
-            for harvester in harvesters:
-                if harvester.get("type") in DCAT_HARVESTER_TYPES:
-                    harvester_dict[harvester["id"]] = harvester.get("url")
+            for pkg in search_dict.get("results", []):
+                pkg_id = pkg.get("id")
+                url = (pkg.get("url") or "").strip()
+
+                if pkg_id and url:
+                    harvester_dict[pkg_id] = url
             return harvester_dict
         except Exception as e:
             log.exception(f"getting harvesters failed: {e}")


### PR DESCRIPTION
As the action harvest_source_list has a default limit of 100(https://github.com/ckan/ckanext-harvest/blob/master/ckanext/harvest/logic/action/get.py#L131) , we are getting the harvest_sources via package_search and filter it by the dataset_type. Otherwise we could also make sure to configure ckan.harvest.harvest_source_limit on the remotes, but I think that is harder to maintain and to debug later on.